### PR TITLE
IE/Edge: prevent autoclose on option click

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,7 @@ export class MultiSelect extends React.Component {
     this.headerRef = React.createRef();
     this.searchRef = React.createRef();
     this.hasListener = false;
+    this.mouseIsHover = false;
   }
 
   componentDidUpdate(pp, ps) {
@@ -137,8 +138,10 @@ export class MultiSelect extends React.Component {
    */
   handleDocumentClick = event => {
     if (this.props.disabled) return;
+  
+    var eventPath = u.eventPath(event);
 
-    if (!u.eventPath(event).includes(this.multiSelectRef.current)) {
+    if ((eventPath === 'undefined' && !this.isSingle() && !this.mouseIsHover) || (eventPath !== 'undefined' && !eventPath.includes(this.multiSelectRef.current))) {
       this.setState({ expanded: false, hasFocus: false });
       u.removeDocumentClickListener(this.handleDocumentClick);
       this.onEvent('onBlur');
@@ -191,6 +194,7 @@ export class MultiSelect extends React.Component {
    * @param expanded Boolean
    */
   handleHover = expanded => {
+    this.mouseIsHover = expanded;
     if (this.props.shouldToggleOnHover) this.toggleDropDown(null, expanded);
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,9 @@ export const stopPreventPropagation = event => {
  */
 export const eventPath = event => {
   const inPath = (event.composedPath && event.composedPath()) || event.path;
+
+  if (typeof inPath === 'undefined') return 'undefined'; // ie/edge
+
   const target = event.target;
 
   if (inPath != null) return (inPath.indexOf(window) < 0) ? inPath.concat(window) : inPath; // safari


### PR DESCRIPTION
Hi again,

IE/Edge does not support [event.composedPath](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath). The function eventPath will always return false clicking on an option.

I did a workaround using a check on whether or not you are "hovering" the MultiSelect when the handleDocumentClick is fired. Works for me :)